### PR TITLE
End the mixture of Unit and *Unit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Many of them provide explanations and formulae,
   1) unit.newUnit - the private, internal factory to create new units => find duplicate names or symbols at compile time
   2) value.MustConvert
   3) units.MustConvertFloat
-- Change the signature of `NewUnit`, return `(*Unit, error)` instead of `Unit`.
+- Change the signature of `NewUnit`, return `(Unit, error)` instead of `Unit`.
 - Extend the Unit struct to support alternative symbols.
 - Symbols are case-sensitive.
 - Names, symbols and aliases must be unique!  

--- a/conversion.go
+++ b/conversion.go
@@ -17,8 +17,8 @@ var (
 type ConversionFn func(float64) float64
 
 type Conversion struct {
-	from    *Unit
-	to      *Unit
+	from    Unit
+	to      Unit
 	Fn      ConversionFn
 	Formula string
 }
@@ -34,7 +34,7 @@ func (c Conversion) From() string { return c.from.Name }
 
 // NewRatioConversion registers a conversion formula and the _inverse_, given a ratio of
 // from Unit in to Unit
-func NewRatioConversion(from, to *Unit, ratio float64) {
+func NewRatioConversion(from, to Unit, ratio float64) {
 	ratioStr := fmt.Sprintf("%.62f", ratio)
 	NewConversionFromFn(
 		from, to, func(x float64) float64 {
@@ -57,7 +57,7 @@ func NewRatioConversion(from, to *Unit, ratio float64) {
 //
 //	NewConversionFromFn(SlopeValue, SlopeDegree, slopeValueToDegree, "math.Atan(x) * 180 / math.Pi")
 //	NewConversionFromFn(SlopeDegree, SlopeValue, slopeDegreeToValue, "math.Tan(x * math.Pi / 180)")
-func NewConversionFromFn(from, to *Unit, f ConversionFn, formula string) {
+func NewConversionFromFn(from, to Unit, f ConversionFn, formula string) {
 	c := Conversion{from, to, f, fmtFormula(formula)}
 	conversions = append(conversions, c)
 	tree.AddEdge(c)
@@ -80,7 +80,7 @@ func fmtFormula(s string) string {
 }
 
 // ResolveConversion resolves a path of one or more Conversions between two units
-func ResolveConversion(from, to *Unit) (cpath []Conversion, err error) {
+func ResolveConversion(from, to Unit) (cpath []Conversion, err error) {
 	path, err := tree.FindPath(from.Name, to.Name)
 	if err != nil {
 		return cpath, errors.New("failed to resolve conversion: " + err.Error())

--- a/conversion_valuate.go
+++ b/conversion_valuate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewConversion registers a new conversion formula from one Unit to another
-func NewConversion(from, to *Unit, formula string) (err error) {
+func NewConversion(from, to Unit, formula string) (err error) {
 	expr, err := govaluate.NewEvaluableExpression(formula)
 	if err != nil {
 		return err

--- a/lookup_test_helpers.go
+++ b/lookup_test_helpers.go
@@ -11,7 +11,7 @@ import (
 
 // lookUpTestUnit is a test unit for looking up names, aliases or symbols.
 type lookUpTestUnit struct {
-	expect *Unit  // the expected unit, or nil if an error is expected
+	expect Unit   // the expected unit, or nil if an error is expected
 	key    string // the name, alias or symbol to look up
 }
 

--- a/metric.go
+++ b/metric.go
@@ -39,33 +39,33 @@ var mags = map[string]magnitude{
 
 // Magnitude prefix methods create and return a new Unit, while automatically registering
 // conversions to and from the provided base Unit
-func Quetta(b *Unit, o ...UnitOption) *Unit { return mags["quetta"].makeUnit(b, o...) }
-func Ronna(b *Unit, o ...UnitOption) *Unit  { return mags["ronna"].makeUnit(b, o...) }
-func Yotta(b *Unit, o ...UnitOption) *Unit  { return mags["yotta"].makeUnit(b, o...) }
-func Zetta(b *Unit, o ...UnitOption) *Unit  { return mags["zetta"].makeUnit(b, o...) }
-func Exa(b *Unit, o ...UnitOption) *Unit    { return mags["exa"].makeUnit(b, o...) }
-func Peta(b *Unit, o ...UnitOption) *Unit   { return mags["peta"].makeUnit(b, o...) }
-func Tera(b *Unit, o ...UnitOption) *Unit   { return mags["tera"].makeUnit(b, o...) }
-func Giga(b *Unit, o ...UnitOption) *Unit   { return mags["giga"].makeUnit(b, o...) }
-func Mega(b *Unit, o ...UnitOption) *Unit   { return mags["mega"].makeUnit(b, o...) }
-func Kilo(b *Unit, o ...UnitOption) *Unit   { return mags["kilo"].makeUnit(b, o...) }
-func Hecto(b *Unit, o ...UnitOption) *Unit  { return mags["hecto"].makeUnit(b, o...) }
-func Deca(b *Unit, o ...UnitOption) *Unit   { return mags["deca"].makeUnit(b, o...) }
-func Deci(b *Unit, o ...UnitOption) *Unit   { return mags["deci"].makeUnit(b, o...) }
-func Centi(b *Unit, o ...UnitOption) *Unit  { return mags["centi"].makeUnit(b, o...) }
-func Milli(b *Unit, o ...UnitOption) *Unit  { return mags["milli"].makeUnit(b, o...) }
-func Micro(b *Unit, o ...UnitOption) *Unit  { return mags["micro"].makeUnit(b, o...) }
-func Nano(b *Unit, o ...UnitOption) *Unit   { return mags["nano"].makeUnit(b, o...) }
-func Pico(b *Unit, o ...UnitOption) *Unit   { return mags["pico"].makeUnit(b, o...) }
-func Femto(b *Unit, o ...UnitOption) *Unit  { return mags["femto"].makeUnit(b, o...) }
-func Atto(b *Unit, o ...UnitOption) *Unit   { return mags["atto"].makeUnit(b, o...) }
-func Zepto(b *Unit, o ...UnitOption) *Unit  { return mags["zepto"].makeUnit(b, o...) }
-func Yocto(b *Unit, o ...UnitOption) *Unit  { return mags["yocto"].makeUnit(b, o...) }
-func Ronto(b *Unit, o ...UnitOption) *Unit  { return mags["ronto"].makeUnit(b, o...) }
-func Quecto(b *Unit, o ...UnitOption) *Unit { return mags["quecto"].makeUnit(b, o...) }
+func Quetta(b Unit, o ...UnitOption) Unit { return mags["quetta"].makeUnit(b, o...) }
+func Ronna(b Unit, o ...UnitOption) Unit  { return mags["ronna"].makeUnit(b, o...) }
+func Yotta(b Unit, o ...UnitOption) Unit  { return mags["yotta"].makeUnit(b, o...) }
+func Zetta(b Unit, o ...UnitOption) Unit  { return mags["zetta"].makeUnit(b, o...) }
+func Exa(b Unit, o ...UnitOption) Unit    { return mags["exa"].makeUnit(b, o...) }
+func Peta(b Unit, o ...UnitOption) Unit   { return mags["peta"].makeUnit(b, o...) }
+func Tera(b Unit, o ...UnitOption) Unit   { return mags["tera"].makeUnit(b, o...) }
+func Giga(b Unit, o ...UnitOption) Unit   { return mags["giga"].makeUnit(b, o...) }
+func Mega(b Unit, o ...UnitOption) Unit   { return mags["mega"].makeUnit(b, o...) }
+func Kilo(b Unit, o ...UnitOption) Unit   { return mags["kilo"].makeUnit(b, o...) }
+func Hecto(b Unit, o ...UnitOption) Unit  { return mags["hecto"].makeUnit(b, o...) }
+func Deca(b Unit, o ...UnitOption) Unit   { return mags["deca"].makeUnit(b, o...) }
+func Deci(b Unit, o ...UnitOption) Unit   { return mags["deci"].makeUnit(b, o...) }
+func Centi(b Unit, o ...UnitOption) Unit  { return mags["centi"].makeUnit(b, o...) }
+func Milli(b Unit, o ...UnitOption) Unit  { return mags["milli"].makeUnit(b, o...) }
+func Micro(b Unit, o ...UnitOption) Unit  { return mags["micro"].makeUnit(b, o...) }
+func Nano(b Unit, o ...UnitOption) Unit   { return mags["nano"].makeUnit(b, o...) }
+func Pico(b Unit, o ...UnitOption) Unit   { return mags["pico"].makeUnit(b, o...) }
+func Femto(b Unit, o ...UnitOption) Unit  { return mags["femto"].makeUnit(b, o...) }
+func Atto(b Unit, o ...UnitOption) Unit   { return mags["atto"].makeUnit(b, o...) }
+func Zepto(b Unit, o ...UnitOption) Unit  { return mags["zepto"].makeUnit(b, o...) }
+func Yocto(b Unit, o ...UnitOption) Unit  { return mags["yocto"].makeUnit(b, o...) }
+func Ronto(b Unit, o ...UnitOption) Unit  { return mags["ronto"].makeUnit(b, o...) }
+func Quecto(b Unit, o ...UnitOption) Unit { return mags["quecto"].makeUnit(b, o...) }
 
 // makeUnit creates a magnitude unit and conversion given a base unit
-func (mag magnitude) makeUnit(base *Unit, addOpts ...UnitOption) *Unit {
+func (mag magnitude) makeUnit(base Unit, addOpts ...UnitOption) Unit {
 	name := mag.Prefix + base.Name
 	symbol := mag.Symbol + base.Symbol
 

--- a/metric_test.go
+++ b/metric_test.go
@@ -25,7 +25,7 @@ var magNames = []string{
 	"atto",
 }
 
-type magFn func(*Unit, ...UnitOption) *Unit
+type magFn func(Unit, ...UnitOption) Unit
 
 func Test_Magnitudes(t *testing.T) {
 	u := newUnit("dong", "₫")

--- a/unit.go
+++ b/unit.go
@@ -60,14 +60,14 @@ var (
 
 	// unitMap is a map of all registered units.
 	// The key is the unit name or alias, the value is the Unit.
-	unitMap = make(map[string]*Unit)
+	unitMap = make(map[string]Unit)
 	// symbolMap is a map of all registered units.
 	// The key is the unit symbol, the value is the Unit.
-	symbolMap = make(map[string]*Unit)
+	symbolMap = make(map[string]Unit)
 )
 
-// Unit represents a unit of measurement
-type Unit struct {
+// unit represents a unit of measurement -- internal representation
+type unit struct {
 	// Name is the (english) name of this unit. The name is mandatory and case-insensitive.
 	Name string
 	// Symbol is the (main) symbol for this unit, e.g. "m" for meters. The symbol is mandatory and case-sensitive.
@@ -87,11 +87,14 @@ type Unit struct {
 	system UnitSystem
 }
 
+// Unit represents a unit of measurement
+type Unit = *unit
+
 // NewUnit registers a new Unit within the package, returning the newly created Unit.
 // Returns an error if the unit already exists.
 // The name is mandatory and must be unique.
 // The symbol is optional, but if provided, must be unique.
-func NewUnit(name, symbol string, opts ...UnitOption) (*Unit, error) {
+func NewUnit(name, symbol string, opts ...UnitOption) (Unit, error) {
 	if name == "" {
 		return nil, errors.New("unit name cannot be empty")
 	}
@@ -104,7 +107,7 @@ func NewUnit(name, symbol string, opts ...UnitOption) (*Unit, error) {
 		}
 	}
 
-	u := &Unit{
+	u := &unit{
 		Name:   name,
 		Symbol: symbol,
 		plural: PluralAuto,
@@ -125,7 +128,7 @@ func NewUnit(name, symbol string, opts ...UnitOption) (*Unit, error) {
 
 // newUnit registers a new Unit within the package, returning the newly created Unit.
 // PANICS if the unit already exists!
-func newUnit(name, symbol string, opts ...UnitOption) *Unit {
+func newUnit(name, symbol string, opts ...UnitOption) Unit {
 	u, err := NewUnit(name, symbol, opts...)
 	if err != nil {
 		panic(err)
@@ -136,7 +139,7 @@ func newUnit(name, symbol string, opts ...UnitOption) *Unit {
 // Names returns all names and aliases this unit may be referred to.
 // The main name is always the first in the list.
 // Names and aliases are NOT case-sensitive!
-func (u *Unit) Names() []string {
+func (u Unit) Names() []string {
 	names := []string{u.Name}
 	if u.plural != PluralNone && u.plural != PluralAuto {
 		names = append(names, u.PluralName())
@@ -145,26 +148,26 @@ func (u *Unit) Names() []string {
 }
 
 // Aliases returns all aliases this unit may be referred to.
-func (u *Unit) Aliases() []string {
+func (u Unit) Aliases() []string {
 	return u.aliases
 }
 
 // Symbols returns all symbols this unit may be referred to.
 // The main symbol is always the first in the list.
 // Symbols are case-sensitive!
-func (u *Unit) Symbols() []string {
+func (u Unit) Symbols() []string {
 	return append([]string{u.Symbol}, u.symbols...)
 }
 
 // String returns the name of this unit
-func (u *Unit) String() string {
+func (u Unit) String() string {
 	return u.Name
 }
 
 // AddResult is the result of adding aliases or symbols to a unit
 type AddResult struct {
 	What     string           // "Aliases" or "Symbols", depending on what was added
-	Unit     *Unit            // the unit to which the aliases or symbols were added
+	Unit     Unit             // the unit to which the aliases or symbols were added
 	Added    []string         // the aliases or symbols that were added
 	Failures map[string]error // the aliases or symbols that failed to be added, and the reason why
 	Err      error            // the overall error that occurred, if any
@@ -192,7 +195,7 @@ func (ar *AddResult) String() string {
 }
 
 // AddAliases adds aliases that this unit may be referred to
-func (u *Unit) AddAliases(aliases ...string) *AddResult {
+func (u Unit) AddAliases(aliases ...string) *AddResult {
 
 	result := &AddResult{
 		What:     "Aliases",
@@ -226,7 +229,7 @@ func (u *Unit) AddAliases(aliases ...string) *AddResult {
 }
 
 // AddSymbols adds symbols that this unit may be referred to
-func (u *Unit) AddSymbols(symbols ...string) *AddResult {
+func (u Unit) AddSymbols(symbols ...string) *AddResult {
 
 	result := &AddResult{
 		What:     "Symbols",
@@ -260,10 +263,10 @@ func (u *Unit) AddSymbols(symbols ...string) *AddResult {
 }
 
 // System returns the system of units this Unit belongs to, if any
-func (u *Unit) System() UnitSystem { return u.system }
+func (u Unit) System() UnitSystem { return u.system }
 
 // PluralName returns the plural name for this unit
-func (u *Unit) PluralName() string {
+func (u Unit) PluralName() string {
 	switch u.plural {
 	case PluralNone:
 		return u.Name
@@ -275,19 +278,19 @@ func (u *Unit) PluralName() string {
 }
 
 // HasName returns true if the provided string matches the provided Unit's Name or Aliases
-func (u *Unit) HasName(alias string) bool {
+func (u Unit) HasName(alias string) bool {
 	return matchesNameOrAlias(alias, u, false) || matchesNameOrAlias(alias, u, true)
 }
 
 // HasSymbol returns true if the provided string matches the provided Unit's Symbol or Symbols
-func (u *Unit) HasSymbol(symbol string) bool {
+func (u Unit) HasSymbol(symbol string) bool {
 	return matchesSymbol(symbol, u)
 }
 
 // CsvLine returns a CSV line for this unit
 // The line contains the following fields:
 // Name, Symbol, PluralName, Quantity, System, Aliases, Symbols
-func (u *Unit) CsvLine() string {
+func (u Unit) CsvLine() string {
 	line := fmt.Sprintf("%s,%s,%s,%s,%s,", u.Name, u.Symbol, u.PluralName(), u.Quantity, u.System())
 	if len(u.aliases) > 0 {
 		line += strings.Join(u.aliases, ",")
@@ -302,19 +305,19 @@ func (u *Unit) CsvLine() string {
 }
 
 // ConvertTo converts the provided value from this unit to the provided unit
-func (u *Unit) ConvertTo(value float64, to *Unit) (Value, error) {
+func (u Unit) ConvertTo(value float64, to Unit) (Value, error) {
 	return ConvertFloat(value, u, to)
 }
 
 // UnitOption defines an option that may be passed to newUnit
-type UnitOption func(*Unit) *Unit
+type UnitOption func(Unit) Unit
 
 // Plural sets the plural name for this unit,
 // either PluralNone, PluralAuto, or a custom plural unit name
 //   - PluralNone - labels will use the unmodified unit name in a plural context
 //   - PluralAuto - labels for this unit will be created with a plural suffix when appropriate (default)
 func Plural(s string) UnitOption {
-	return func(u *Unit) *Unit {
+	return func(u Unit) Unit {
 		u.plural = s
 		return u
 	}
@@ -322,7 +325,7 @@ func Plural(s string) UnitOption {
 
 // System sets the system of units for which this Unit belongs
 func System(s UnitSystem) UnitOption {
-	return func(u *Unit) *Unit {
+	return func(u Unit) Unit {
 		u.system = s
 		return u
 	}
@@ -330,7 +333,7 @@ func System(s UnitSystem) UnitOption {
 
 // Quantity sets a quantity label for which this Unit belongs
 func Quantity(s UnitQuantity) UnitOption {
-	return func(u *Unit) *Unit {
+	return func(u Unit) Unit {
 		u.Quantity = s
 		return u
 	}
@@ -338,7 +341,8 @@ func Quantity(s UnitQuantity) UnitOption {
 
 // Aliases sets the aliases for this Unit
 func Aliases(aliases ...string) UnitOption {
-	return func(u *Unit) *Unit {
+	return func(u Unit) Unit {
+		u.System()
 		u.AddAliases(aliases...)
 		return u
 	}
@@ -346,14 +350,14 @@ func Aliases(aliases ...string) UnitOption {
 
 // Symbols sets the symbols for this Unit
 func Symbols(symbols ...string) UnitOption {
-	return func(u *Unit) *Unit {
+	return func(u Unit) Unit {
 		u.AddSymbols(symbols...)
 		return u
 	}
 }
 
 // UnitList is a slice of Units. UnitList implements sort.Interface
-type UnitList []*Unit
+type UnitList []Unit
 
 // Len returns the length of the UnitList
 func (a UnitList) Len() int {

--- a/units.go
+++ b/units.go
@@ -13,7 +13,7 @@ import (
 const CsvHeader = "Name,Symbol,PluralName,Quantity,System,Aliases & Symbols"
 
 // All returns all registered Units, sorted by name and quantity
-func All() []*Unit {
+func All() []Unit {
 	units := make(UnitList, 0, len(unitMap))
 	for _, u := range unitMap {
 		units = append(units, u)
@@ -23,7 +23,7 @@ func All() []*Unit {
 }
 
 // MustConvertFloat converts a provided float from one Unit to another, PANICKING on error
-func MustConvertFloat(x float64, from, to *Unit) Value {
+func MustConvertFloat(x float64, from, to Unit) Value {
 	val, err := ConvertFloat(x, from, to)
 	if err != nil {
 		panic(err)
@@ -32,10 +32,10 @@ func MustConvertFloat(x float64, from, to *Unit) Value {
 }
 
 // ConvertFloat converts a provided float from one Unit to another
-func ConvertFloat(x float64, from, to *Unit) (Value, error) {
+func ConvertFloat(x float64, from, to Unit) (Value, error) {
 	// allow converting to same unit
 	if from == to {
-		return Value{x, *to}, nil
+		return Value{x, to}, nil
 	}
 
 	// find conversion path
@@ -49,11 +49,11 @@ func ConvertFloat(x float64, from, to *Unit) (Value, error) {
 		x = c.Fn(x)
 	}
 
-	return Value{x, *to}, nil
+	return Value{x, to}, nil
 }
 
 // Find a Unit matching the given name, symbol or alias
-func Find(s string) (*Unit, error) {
+func Find(s string) (Unit, error) {
 
 	// first try case-sensitive match on name
 	u, ok := unitMap[s]
@@ -89,7 +89,7 @@ func Find(s string) (*Unit, error) {
 }
 
 // matchesNameOrAlias returns true if the provided string matches the provided Unit's name or aliases
-func matchesNameOrAlias(s string, u *Unit, matchCase bool) bool {
+func matchesNameOrAlias(s string, u Unit, matchCase bool) bool {
 	for _, name := range u.Names() {
 		if matchCase {
 			if name == s {
@@ -106,7 +106,7 @@ func matchesNameOrAlias(s string, u *Unit, matchCase bool) bool {
 }
 
 // matchesSymbol returns true if the provided string matches the provided Unit's symbol
-func matchesSymbol(s string, u *Unit) bool {
+func matchesSymbol(s string, u Unit) bool {
 	// symbols are case-sensitive!
 	for _, sym := range u.Symbols() {
 		if sym == s {
@@ -120,7 +120,7 @@ func matchesSymbol(s string, u *Unit) bool {
 func GetCsv() []string {
 
 	// unitMap contains 'duplicate' units, because they are registered multiple times with different names/aliases
-	uniqueUnits := make(map[string]*Unit)
+	uniqueUnits := make(map[string]Unit)
 	for _, u := range unitMap {
 		uniqueUnits[u.Name] = u
 	}

--- a/units_test.go
+++ b/units_test.go
@@ -15,12 +15,12 @@ func aggrNames() (a []string) {
 }
 
 // aggregate units by quantity
-func aggrByQuantity() map[UnitQuantity][]*Unit {
-	m := make(map[UnitQuantity][]*Unit)
+func aggrByQuantity() map[UnitQuantity][]Unit {
+	m := make(map[UnitQuantity][]Unit)
 
 	for _, u := range All() {
 		if _, ok := m[u.Quantity]; !ok {
-			m[u.Quantity] = []*Unit{}
+			m[u.Quantity] = []Unit{}
 		}
 		m[u.Quantity] = append(m[u.Quantity], u)
 	}
@@ -66,12 +66,12 @@ func Test_PathResolve(t *testing.T) {
 		}
 		t.Logf("testing conversion paths for quantity: %s", qname)
 		for _, u1 := range qunits {
-			v1 := NewValue(1.0, *u1)
+			v1 := NewValue(1.0, u1)
 			for _, u2 := range qunits {
 				if u1.Name == u2.Name {
 					continue
 				}
-				_, err := v1.Convert(*u2)
+				_, err := v1.Convert(u2)
 				if err != nil {
 					t.Errorf("failed to resolve path: %s -> %s", u1.Name, u2.Name)
 				}

--- a/value.go
+++ b/value.go
@@ -76,7 +76,7 @@ func (v Value) Convert(to Unit) (Value, error) {
 		return v, nil
 	}
 
-	return ConvertFloat(v.val, &v.unit, &to)
+	return ConvertFloat(v.val, v.unit, to)
 }
 
 // Trim trailing zeros from formatted float string


### PR DESCRIPTION
Units have been used as `*Unit` all over the place -- except for some places (namely conversions), where `Unit` was used.

Units are now always pointer to an internal struct `unit`. For usage purposes, the type alias `Unit = *unit` has been defined (as I see the pointiness of units to be an implementation detail and not worth pointing out to users).

Another approach would've been to use `type Unit struct { *unit }` that completely decouples them.