### PR TITLE
Feature to convert a value into a human readable one

### DIFF
--- a/angle_units.go
+++ b/angle_units.go
@@ -7,14 +7,14 @@ var (
 
 	Turn = newUnit("turn", "tr", Angle)
 
-	Radian      = newUnit("radian", "rad", Angle, SI)
+	Radian      = newUnit("radian", "rad", Angle, SI, BaseUnit)
 	MilliRadian = Milli(Radian)
 	MicroRadian = Micro(Radian)
 
 	// Degree (= decimal degree) is a unit of angle equal to 1/360 of a circle.
 	Degree = newUnit("degree", "°", Angle)
 
-	Gon      = newUnit("gon", "gon", Angle, Symbols("grad"))
+	Gon      = newUnit("gon", "gon", Angle, BaseUnit, Symbols("grad"))
 	DeciGon  = Deci(Gon)
 	CentiGon = Centi(Gon)
 	MilliGon = Milli(Gon)

--- a/electric_charge_units.go
+++ b/electric_charge_units.go
@@ -4,7 +4,7 @@ var (
 	ElectricCharge = Quantity("electric charge")
 
 	// SI unit metric
-	Coulomb      = newUnit("coulomb", "C", ElectricCharge, SI)
+	Coulomb      = newUnit("coulomb", "C", ElectricCharge, SI, BaseUnit)
 	ExaCoulomb   = Exa(Coulomb)
 	PetaCoulomb  = Peta(Coulomb)
 	TeraCoulomb  = Tera(Coulomb)
@@ -22,17 +22,17 @@ var (
 	FemtoCoulomb = Femto(Coulomb)
 	AttoCoulomb  = Atto(Coulomb)
 
-	AmpereHour      = newUnit("ampere-hour", "A·h", ElectricCharge, SI, Symbols("A⋅h", "A*h", "A.h", "Ah", "AHr"))
+	AmpereHour      = newUnit("ampere-hour", "A·h", ElectricCharge, SI, Symbols("A⋅h", "A*h", "A.h", "Ah", "AHr"), BaseUnit)
 	KiloAmpereHour  = Kilo(AmpereHour)
 	MilliAmpereHour = Milli(AmpereHour)
 
 	AmpereMinute = newUnit(
-		"ampere-minute", "A·min", ElectricCharge, SI, Symbols("A⋅min", "A*min", "A.min", "Amin"),
+		"ampere-minute", "A·min", ElectricCharge, SI, BaseUnit, Symbols("A⋅min", "A*min", "A.min", "Amin"),
 	)
 	KiloAmpereMinute  = Kilo(AmpereMinute)
 	MilliAmpereMinute = Milli(AmpereMinute)
 
-	AmpereSecond      = newUnit("ampere-second", "A·s", ElectricCharge, SI, Symbols("A⋅s", "A*s", "A.s", "As"))
+	AmpereSecond      = newUnit("ampere-second", "A·s", ElectricCharge, SI, BaseUnit, Symbols("A⋅s", "A*s", "A.s", "As"))
 	KiloAmpereSecond  = Kilo(AmpereSecond)
 	MilliAmpereSecond = Milli(AmpereSecond)
 )

--- a/electric_current_units.go
+++ b/electric_current_units.go
@@ -4,7 +4,7 @@ var (
 	ElectricCurrent = Quantity("electric current")
 
 	// metric
-	Ampere      = newUnit("ampere", "A", ElectricCurrent, SI)
+	Ampere      = newUnit("ampere", "A", ElectricCurrent, SI, BaseUnit)
 	MilliAmpere = Milli(Ampere)
 	MicroAmpere = Micro(Ampere)
 	NanoAmpere  = Nano(Ampere)

--- a/electrical_resistance_units.go
+++ b/electrical_resistance_units.go
@@ -3,7 +3,7 @@ package units
 var (
 	ElectricalResistance = Quantity("electrical resistance")
 
-	Ohm      = newUnit("ohm", "Ω", ElectricalResistance, SI, Symbols("Ω"))
+	Ohm      = newUnit("ohm", "Ω", ElectricalResistance, SI, Symbols("Ω"), BaseUnit)
 	DecaOhm  = Deca(Ohm)
 	HectoOhm = Hecto(Ohm)
 	KiloOhm  = Kilo(Ohm)

--- a/energy_units.go
+++ b/energy_units.go
@@ -4,7 +4,7 @@ var (
 	Energy = Quantity("energy")
 
 	// metric
-	Joule      = newUnit("joule", "J", Energy, SI)
+	Joule      = newUnit("joule", "J", Energy, SI, BaseUnit)
 	KiloJoule  = Kilo(Joule)
 	MegaJoule  = Mega(Joule)
 	GigaJoule  = Giga(Joule)
@@ -24,6 +24,7 @@ var (
 		"watt-hour", "Wh", Energy, SI,
 		Aliases("volt ampere hour", "volt ampere reactive hour", "volt ampere hour (reactive)"),
 		Symbols("VAh", "varh", "V⋅A⋅hr", "V.A.h", "V.A{reactive}.h", "V⋅A{reactive}⋅hr"),
+		BaseUnit,
 	)
 	KiloWattHour = Kilo(WattHour)
 	MegaWattHour = Mega(WattHour)
@@ -32,12 +33,12 @@ var (
 	PetaWattHour = Peta(WattHour)
 
 	// other
-	ElectronVolt     = newUnit("electronvolt", "eV", Energy)
+	ElectronVolt     = newUnit("electronvolt", "eV", Energy, BaseUnit)
 	KiloElectronVolt = Kilo(ElectronVolt)
 	MegaElectronVolt = Mega(ElectronVolt)
 	GigaElectronVolt = Giga(ElectronVolt)
 
-	Calorie     = newUnit("calorie", "cal", Energy)
+	Calorie     = newUnit("calorie", "cal", Energy, BaseUnit)
 	KiloCalorie = Kilo(Calorie)
 )
 

--- a/force_units.go
+++ b/force_units.go
@@ -3,7 +3,7 @@ package units
 var (
 	Force = Quantity("force")
 
-	Newton      = newUnit("newton", "N", Force, SI)
+	Newton      = newUnit("newton", "N", Force, SI, BaseUnit)
 	CentiNewton = Centi(Newton)
 	DeciNewton  = Deci(Newton)
 	MilliNewton = Milli(Newton)

--- a/frequency_units.go
+++ b/frequency_units.go
@@ -5,7 +5,7 @@ import "math"
 var (
 	Frequency = Quantity("frequency")
 
-	Hertz      = newUnit("hertz", "Hz", Frequency, SI)
+	Hertz      = newUnit("hertz", "Hz", Frequency, SI, BaseUnit)
 	DecaHertz  = Deca(Hertz)
 	HectoHertz = Hecto(Hertz)
 	KiloHertz  = Kilo(Hertz)

--- a/length_units.go
+++ b/length_units.go
@@ -4,7 +4,7 @@ var (
 	Length = Quantity("length")
 
 	// metric
-	Meter      = newUnit("meter", "m", Length, SI)
+	Meter      = newUnit("meter", "m", Length, SI, BaseUnit)
 	ExaMeter   = Exa(Meter)
 	PetaMeter  = Peta(Meter)
 	TeraMeter  = Tera(Meter)

--- a/mass_units.go
+++ b/mass_units.go
@@ -4,7 +4,7 @@ var (
 	Mass = Quantity("mass")
 
 	// metric
-	Gram      = newUnit("gram", "g", Mass, SI)
+	Gram      = newUnit("gram", "g", Mass, SI, BaseUnit)
 	ExaGram   = Exa(Gram)
 	PetaGram  = Peta(Gram)
 	TeraGram  = Tera(Gram)

--- a/metric.go
+++ b/metric.go
@@ -64,6 +64,49 @@ func Yocto(b *Unit, o ...UnitOption) *Unit  { return mags["yocto"].makeUnit(b, o
 func Ronto(b *Unit, o ...UnitOption) *Unit  { return mags["ronto"].makeUnit(b, o...) }
 func Quecto(b *Unit, o ...UnitOption) *Unit { return mags["quecto"].makeUnit(b, o...) }
 
+// magnitudeForExp returns the magnitude for the given exponent.
+// If such a magnitude is not defined, fall back to the "base magnitude", i.e., with Power 0.
+func magnitudeForExp(exp float64) magnitude {
+	for _, mag := range mags {
+		if mag.Power == exp {
+			return mag
+		}
+	}
+
+	// if in doubt: fall back to base case
+	return magnitude{
+		Symbol: "",
+		Prefix: "",
+		Power:  0,
+	}
+}
+
+// findMaxUnitForExp returns the largest Unit that can be created from the given Unit
+// and exponent. If such a Unit is not defined, return the passed unit unchanged.
+func findMaxUnitForExp(u *Unit, exp float64) *Unit {
+	if exp == 0 || !u.IsMetric() {
+		return u
+	}
+	mag := magnitudeForExp(exp)
+	if mag.Power != 0 {
+		name := mag.Prefix + u.Name
+		maxU, ok := unitMap[name]
+		if ok {
+			// positive case -> found something
+			return maxU
+		}
+	}
+
+	// Unit not found -- scale back
+	if exp > 0 {
+		exp--
+	} else {
+		exp++
+	}
+	return findMaxUnitForExp(u, exp)
+
+}
+
 // makeUnit creates a magnitude unit and conversion given a base unit
 func (mag magnitude) makeUnit(base *Unit, addOpts ...UnitOption) *Unit {
 	name := mag.Prefix + base.Name
@@ -91,6 +134,7 @@ func (mag magnitude) makeUnit(base *Unit, addOpts ...UnitOption) *Unit {
 	opts = append(opts, Quantity(base.Quantity))
 
 	u := newUnit(name, symbol, opts...)
+	u.base = base
 
 	// only create conversions to and from base unit
 	ratio := 1.0 * math.Pow(10.0, mag.Power)

--- a/metric_test.go
+++ b/metric_test.go
@@ -37,3 +37,42 @@ func Test_Magnitudes(t *testing.T) {
 		assert.Equal(t, mu.Name, magNames[i]+"dong")
 	}
 }
+
+func Test_MagnitudeForExp(t *testing.T) {
+	assert.Equal(t, mags["kilo"], magnitudeForExp(3.0))
+	assert.Equal(t, mags["centi"], magnitudeForExp(-2.0))
+	assert.Equal(t, mags["atto"], magnitudeForExp(-18.0))
+	assert.Equal(t, mags["yotta"], magnitudeForExp(24.0))
+
+	// does not exist
+	assert.Zero(t, magnitudeForExp(4.0).Power)
+	assert.Zero(t, magnitudeForExp(1.2).Power)
+	assert.Zero(t, magnitudeForExp(0).Power)
+}
+
+func Test_FindMaxUnitForExp(t *testing.T) {
+	tests := []struct {
+		name   string
+		exp    float64
+		expect *Unit
+		base   *Unit
+	}{
+		{"Zero", 0, Hertz, Hertz},
+		{"Non metric", 3, Foot, Foot},
+		{"Simple", 3, KiloHertz, Hertz},
+		{"Simple negative", -3, MilliHertz, Hertz},
+		{"Simple, unusual", 2, HectoHertz, Hertz},
+		{"Not defined prefix", 2, VoltAmpere, VoltAmpere},
+		{"Partially defined, works", 3, KiloVoltAmpere, VoltAmpere},
+		{"Simple, not existing prefix", 5, KiloHertz, Hertz},
+		{"Partially defined, over", 9, MegaVoltAmpere, VoltAmpere},
+		{"Partially defined negative", -10, VoltAmpere, VoltAmpere},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			calcUnit := findMaxUnitForExp(tst.base, tst.exp)
+			assert.Equal(t, tst.expect, calcUnit)
+		})
+	}
+}

--- a/power_units.go
+++ b/power_units.go
@@ -4,7 +4,7 @@ var (
 	Power = Quantity("power")
 
 	// metric
-	Watt      = newUnit("watt", "W", Power, SI)
+	Watt      = newUnit("watt", "W", Power, SI, BaseUnit)
 	DeciWatt  = Deci(Watt)
 	CentiWatt = Centi(Watt)
 	MilliWatt = Milli(Watt)
@@ -26,11 +26,11 @@ var (
 	ZettaWatt = Zetta(Watt)
 	YottaWatt = Yotta(Watt)
 
-	VoltAmpere     = newUnit("volt-ampere", "V⋅A", Power, SI)
+	VoltAmpere     = newUnit("volt-ampere", "V⋅A", Power, SI, BaseUnit)
 	KiloVoltAmpere = Kilo(VoltAmpere)
 	MegaVoltAmpere = Mega(VoltAmpere)
 
-	VoltAmpereReactive     = newUnit("volt-ampere reactive", "var", Power, SI)
+	VoltAmpereReactive     = newUnit("volt-ampere reactive", "var", Power, SI, BaseUnit)
 	KiloVoltAmpereReactive = Kilo(VoltAmpereReactive)
 	MegaVoltAmpereReactive = Mega(VoltAmpereReactive)
 )

--- a/pressure_units.go
+++ b/pressure_units.go
@@ -4,7 +4,7 @@ var (
 	Pressure = Quantity("pressure")
 
 	// SI unit metric
-	Pascal      = newUnit("pascal", "Pa", Pressure, SI)
+	Pascal      = newUnit("pascal", "Pa", Pressure, SI, BaseUnit)
 	ExaPascal   = Exa(Pascal)
 	PetaPascal  = Peta(Pascal)
 	TeraPascal  = Tera(Pascal)

--- a/time_units.go
+++ b/time_units.go
@@ -3,7 +3,7 @@ package units
 var (
 	Time = Quantity("time")
 
-	Second      = newUnit("second", "s", Time, SI)
+	Second      = newUnit("second", "s", Time, SI, BaseUnit)
 	ExaSecond   = Exa(Second)
 	PetaSecond  = Peta(Second)
 	TeraSecond  = Tera(Second)

--- a/unit.go
+++ b/unit.go
@@ -85,6 +85,8 @@ type Unit struct {
 	symbols []string
 	// system is the system of units this Unit belongs to, if any.
 	system UnitSystem
+	// base is the base unit for metric units
+	base *Unit
 }
 
 // NewUnit registers a new Unit within the package, returning the newly created Unit.
@@ -306,6 +308,16 @@ func (u *Unit) ConvertTo(value float64, to *Unit) (Value, error) {
 	return ConvertFloat(value, u, to)
 }
 
+// IsMetric returns true if this unit is metric.
+func (u *Unit) IsMetric() bool {
+	return u.base != nil
+}
+
+// BaseUnit returns the base unit for metric units, or nil for non-metric units.
+func (u *Unit) BaseUnit() *Unit {
+	return u.base
+}
+
 // UnitOption defines an option that may be passed to newUnit
 type UnitOption func(*Unit) *Unit
 
@@ -350,6 +362,12 @@ func Symbols(symbols ...string) UnitOption {
 		u.AddSymbols(symbols...)
 		return u
 	}
+}
+
+// BaseUnit marks this unit as the base unit for metric units
+var BaseUnit UnitOption = func(u *Unit) *Unit {
+	u.base = u
+	return u
 }
 
 // UnitList is a slice of Units. UnitList implements sort.Interface

--- a/value.go
+++ b/value.go
@@ -79,6 +79,41 @@ func (v Value) Convert(to Unit) (Value, error) {
 	return ConvertFloat(v.val, &v.unit, &to)
 }
 
+// AsBaseUnit converts this Value to its base unit (i.e., 2km to 2000m).
+func (v Value) AsBaseUnit() Value {
+	if !v.unit.IsMetric() {
+		return v
+	}
+
+	// we can use "Must" here because we know that the unit is metric
+	// and then this conversion is defined.
+	return v.MustConvert(*v.unit.BaseUnit())
+}
+
+// Humanize converts this Value to a human-readable format (i.e., 2000m to 2km).
+func (v Value) Humanize() Value {
+	if !v.unit.IsMetric() || v.val == 0 {
+		return v
+	}
+
+	// Algorithm taken from go-humanize
+	baseV := v.AsBaseUnit()
+	mag := math.Abs(baseV.val)
+	exponent := math.Floor(math.Log10(mag))
+	exponent = math.Floor(exponent/3) * 3
+
+	value := mag / math.Pow(10, exponent)
+
+	// Handle special case where value is exactly 1000.0
+	// Should return 1 M instead of 1000 k
+	if value == 1000.0 {
+		exponent += 3
+	}
+
+	scaledUnit := findMaxUnitForExp(&baseV.unit, exponent)
+	return baseV.MustConvert(*scaledUnit)
+}
+
 // Trim trailing zeros from formatted float string
 func trimTrailing(s string) string {
 	if !strings.ContainsRune(s, '.') {

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,59 @@
+package units
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func nv(val float64, u *Unit) Value {
+	return NewValue(val, *u)
+}
+
+func TestValue_AsBaseUnit(t *testing.T) {
+	tests := []struct {
+		name  string
+		v     Value
+		baseV Value
+	}{
+		{"simple", nv(1, KiloHertz), nv(1000, Hertz)},
+		{"negative", nv(-1, MegaHertz), nv(-1000*1000, Hertz)},
+		{"fraction", nv(1, MilliMeter), nv(0.001, Meter)},
+		{"neg. fraction", nv(-1, MilliMeter), nv(-0.001, Meter)},
+		{"non metric", nv(1, Foot), nv(1, Foot)},
+		{"unequal to one", nv(2.5, KiloOhm), nv(2500, Ohm)},
+		{"base", nv(1000, Hertz), nv(1000, Hertz)},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			baseV := tst.v.AsBaseUnit()
+			assert.Equal(t, tst.baseV, baseV)
+		})
+	}
+}
+
+func TestValue_Humanize(t *testing.T) {
+	tests := []struct {
+		name string
+		v    Value
+		humV Value
+	}{
+		{"base", nv(1, Hertz), nv(1, Hertz)},
+		{"simple", nv(1000, Hertz), nv(1, KiloHertz)},
+		{"negative", nv(-1000, Hertz), nv(-1, KiloHertz)},
+		{"fraction", nv(0.001, Meter), nv(1, MilliMeter)},
+		{"neg. fraction", nv(-0.001, Meter), nv(-1, MilliMeter)},
+		{"non metric", nv(1000, Foot), nv(1000, Foot)},
+		{"unequal to one", nv(2500, Ohm), nv(2.5, KiloOhm)},
+		{"multiple steps", nv(50000000, DeciHertz), nv(5, MegaHertz)},
+		{"only in steps 3", nv(200, Hertz), nv(200, Hertz)},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			humV := tst.v.Humanize()
+			assert.Equal(t, tst.humV, humV)
+		})
+	}
+}

--- a/voltage_units.go
+++ b/voltage_units.go
@@ -4,7 +4,7 @@ var (
 	Voltage = Quantity("voltage")
 
 	// metric
-	Volt      = newUnit("volt", "V", Voltage, SI)
+	Volt      = newUnit("volt", "V", Voltage, SI, BaseUnit)
 	YottaVolt = Yotta(Volt)
 	ZettaVolt = Zetta(Volt)
 	ExaVolt   = Exa(Volt)

--- a/volume_units.go
+++ b/volume_units.go
@@ -5,7 +5,7 @@ var (
 
 	// metric
 
-	Liter      = newUnit("liter", "l", Volume, SI, Aliases("litre"))
+	Liter      = newUnit("liter", "l", Volume, SI, BaseUnit, Aliases("litre"))
 	ExaLiter   = Exa(Liter)
 	PetaLiter  = Peta(Liter)
 	TeraLiter  = Tera(Liter)


### PR DESCRIPTION
Possibility to convert values of metric units into more human-friendly variants (i.e., 2000 Hz -> 2 kHz; 0.001m -> 1mm; ...).

NB: To be really useful, #2 is needed prior (else construncting `Value`s is awkward).